### PR TITLE
add: AI Model Gateway (gateway-oss)

### DIFF
--- a/data/providers.yaml
+++ b/data/providers.yaml
@@ -239,3 +239,15 @@ self_hosted_alternatives:
     supports_stream: true
     supports_tools: true
     notes: "Fork of One-API with extra channel types; same self-hosted model — you supply keys."
+
+  - name: AI Model Gateway
+    url: https://github.com/SSC-STUDIO/Ai-Model-Gateway
+    type: gateway-oss
+    status: active
+    models: [openai, anthropic]
+    last_verified: "2026-05-30"
+    verified_by: community
+    entity_registered: false
+    supports_stream: true
+    supports_tools: unknown
+    notes: "Self-hosted LLM operations gateway with provider routing, fallback, telemetry, config publishing, and rollback."


### PR DESCRIPTION
## What this changes  Adds AI Model Gateway as a self-hosted `gateway-oss` alternative in `data/providers.yaml`.  ## Checklist  - [x] Edited `data/providers.yaml` (not the README tables directly) - [x] Followed [`data/schema.md`](../data/schema.md) - [x] `status` honest (`unverified` if I couldn't verify it myself) - [x] No referral/affiliate links, no marketing copy - [x] Claims have a dated source where non-obvious - [x] Bumped `last_reviewed` if this was a broad pass  ## Source / verification  Verified from the public repository metadata and README: https://github.com/SSC-STUDIO/Ai-Model-Gateway  I marked `verified_by: community` and kept `supports_tools: unknown` to avoid over-claiming beyond the public description. The project is a public self-hosted LLM operations gateway with OpenAI/Anthropic compatibility, provider routing/fallback, telemetry, config publishing, and rollback docs.
## Reviewer evidence

- Quality evidence: https://github.com/SSC-STUDIO/Ai-Model-Gateway/blob/main/docs/quality-evidence.md
- CI workflow: https://github.com/SSC-STUDIO/Ai-Model-Gateway/actions/workflows/ci.yml
- The repository is early by public adoption signals, so the quality evidence page lists the current CI gates, local reproduction commands, runtime smoke checks, feature proof points, and capability boundaries for maintainers to review without broad compatibility claims.
## Client integration evidence

- Client integration guide: https://github.com/SSC-STUDIO/Ai-Model-Gateway/blob/main/docs/client-integrations.md
- Shows how Codex, Claude Code, OpenClaw, generic OpenAI-compatible SDK clients, Anthropic-style clients, and curl smoke tests can point at the gateway.
- This is client-side setup evidence only; it does not claim every downstream tool feature is certified.
## Adoption checklist evidence

- Adoption checklist: https://ssc-studio.github.io/Ai-Model-Gateway/llm-gateway-adoption-checklist.html
- Covers fit, install paths, client compatibility, provider fallback, config publish, rollback, quality evidence, and security for maintainers who want a short evaluation path.