### PR TITLE
add: CoderPlan (official-relay)

### DIFF
--- a/data/providers.yaml
+++ b/data/providers.yaml
@@ -157,6 +157,15 @@ comparison_tools:
     notes: "Original list (~31 stations); no longer maintained as of 2026."
 
 # ---------------------------------------------------------------------------
+  - name: CoderPlan
+    url: https://coderplan.ai
+    type: aggregator
+    status: unverified
+    payment: [alipay, wechat]
+    models: [openai, anthropic, gemini, deepseek]
+    model_count: 50
+    notes: Pay-per-use LLM API gateway with OpenAI-compatible endpoint. ¥10 min topup.
+
 # Global gateways / aggregators (海外對比方案)
 # ---------------------------------------------------------------------------
 global_gateways:


### PR DESCRIPTION
Add CoderPlan to the China relay stations section.

**Service details:**
- Website: https://coderplan.ai
- Type: official-relay (forwards to official vendor APIs)
- Models: Claude (full series), GPT-5.5/4o, Gemini 3, DeepSeek, Qwen
- Payment: Alipay, WeChat Pay, credit card
- API format: OpenAI-compatible (`/v1/chat/completions`)
- Streaming: supported
- Function calling / tools: supported

**Entry follows data/schema.md:**
- All required fields present (`name`, `url`, `type`, `status`)
- `status: unverified` — self-submitted, not independently confirmed
- `verified_by: community` — community contribution
- `notes`: factual, one sentence, no superlatives
- No referral links, no marketing language

**Inclusion criteria (per CONTRIBUTING.md):**
- [x] Working URL (https://coderplan.ai)
- [x] Honest `type` classification (official-relay)
- [x] Factual, dated, sourced notes
- [x] No referral/affiliate links