### PR TITLE
add: FerryAPI (aggregator)

### DIFF
--- a/data/providers.yaml
+++ b/data/providers.yaml
@@ -214,6 +214,19 @@ global_gateways:
     supports_tools: unknown
     notes: "Prepaid from $20; crypto support implies payment-friction workaround."
 
+  - name: FerryAPI
+    url: https://www.ferryapi.io/
+    type: aggregator
+    status: unverified
+    payment: [card]
+    models: [deepseek, qwen, kimi, mimo]
+    last_verified: null
+    verified_by: community
+    entity_registered: unknown
+    supports_stream: unknown
+    supports_tools: unknown
+    notes: "OpenAI-compatible gateway with prepaid balance and customer API key management; community-submitted, not independently verified."
+
 # ---------------------------------------------------------------------------
 # Self-hosted alternatives (自架閘道，供參考對比 — 非「中轉站」)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this changes

Adds FerryAPI as an unverified global aggregator entry in `data/providers.yaml`.

## Checklist

- [x] Edited `data/providers.yaml` (not the README tables directly)
- [x] Followed `data/schema.md`
- [x] `status` honest (`unverified` because I did not independently verify upstream/channel details)
- [x] No referral/affiliate links, no marketing copy
- [x] Claims have a dated source where non-obvious
- [x] Did not bump `last_reviewed` because this is not a broad review pass

## Source / verification

I verified that the official site is reachable at https://www.ferryapi.io/ and that the public site describes an OpenAI-compatible API gateway with prepaid balance and customer API key management.

I am working on FerryAPI, so I marked the listing as community-submitted/unverified and kept stream/tools/entity details as `unknown` instead of asserting them.