### PR TITLE
add: FerryAPI global gateway

### DIFF
--- a/data/providers.yaml
+++ b/data/providers.yaml
@@ -188,6 +188,19 @@ global_gateways:
     supports_tools: true
     notes: "Open-source gateway + enterprise tier. Self-hosted; not retail."
 
+  - name: FerryAPI
+    url: https://www.ferryapi.io
+    type: aggregator
+    status: unverified
+    payment: [card]
+    models: [openai, anthropic, google, deepseek, qwen]
+    last_verified: null
+    verified_by: community
+    entity_registered: unknown
+    supports_stream: unknown
+    supports_tools: unknown
+    notes: "OpenAI-compatible global gateway with prepaid USD balance and customer API-key management; submitted by an affiliated contributor."
+
   - name: Helicone
     url: https://helicone.ai
     type: observability


### PR DESCRIPTION
## What this changes
Adds FerryAPI as an unverified global gateway / aggregator candidate in `data/providers.yaml`.

## Checklist
- [x] Edited `data/providers.yaml` (not the README tables directly)
- [x] Followed `data/schema.md`
- [x] `status` honest: set to `unverified` because I am an affiliated contributor and did not do an independent maintainer verification
- [x] No referral/affiliate links, no marketing copy
- [x] Claims kept factual and conservative
- [x] Did not bump `last_reviewed` because this is not a broad review pass

## Source / verification
Official site: https://www.ferryapi.io

Disclosure: I am affiliated with FerryAPI. I marked the entry `unverified`, set `verified_by: community`, and used a neutral one-sentence note so maintainers can independently verify or adjust the classification.