### PR TITLE
feat: add CoderPlan to China relay stations

### DIFF
--- a/data/providers.yaml
+++ b/data/providers.yaml
@@ -135,19 +135,6 @@ china_relays:
     supports_stream: true
     supports_tools: true
     notes: "Issues enterprise invoices; self-describes as largest enterprise-grade relay in Asia."
-- name: CoderPlan
-  url: https://coderplan.ai
-  type: mixed
-  status: unverified
-  payment: [alipay, wechat]
-  models: [openai, anthropic, gemini, deepseek]
-  last_verified: null
-  verified_by: community
-  entity_registered: unknown
-  supports_stream: true
-  supports_tools: true
-  notes: "OpenAI-compatible API relay with competitive pricing and free credits on signup."
-
 
 # ---------------------------------------------------------------------------
 # Comparison / monitoring tools (中轉站對比工具)
@@ -172,6 +159,21 @@ comparison_tools:
 # ---------------------------------------------------------------------------
 # Global gateways / aggregators (海外對比方案)
 # ---------------------------------------------------------------------------
+
+  - name: CoderPlan
+    url: https://coderplan.ai
+    type: official-relay
+    status: unverified
+    payment: [alipay, wechat]
+    models: [openai, anthropic, google, deepseek, xai]
+    model_count: 50
+    discount_vs_official: "~70% cheaper (claimed)"
+    last_verified: null
+    verified_by: community
+    entity_registered: unknown
+    supports_stream: true
+    supports_tools: true
+    notes: "OpenAI-compatible relay targeting Chinese developers; domestic direct connect, ¥10 minimum top-up."
 global_gateways:
   - name: OpenRouter
     url: https://openrouter.ai

--- a/data/providers.yaml
+++ b/data/providers.yaml
@@ -135,6 +135,19 @@ china_relays:
     supports_stream: true
     supports_tools: true
     notes: "Issues enterprise invoices; self-describes as largest enterprise-grade relay in Asia."
+- name: CoderPlan
+  url: https://coderplan.ai
+  type: mixed
+  status: unverified
+  payment: [alipay, wechat]
+  models: [openai, anthropic, gemini, deepseek]
+  last_verified: null
+  verified_by: community
+  entity_registered: unknown
+  supports_stream: true
+  supports_tools: true
+  notes: "OpenAI-compatible API relay with competitive pricing and free credits on signup."
+
 
 # ---------------------------------------------------------------------------
 # Comparison / monitoring tools (中轉站對比工具)


### PR DESCRIPTION
## Addition: CoderPlan (API 中轉站)

Added CoderPlan to the `china_relays` section in `data/providers.yaml`.

### Details
- **URL**: https://coderplan.ai
- **Type**: mixed (official + other channels)
- **Models**: OpenAI, Anthropic, Gemini, DeepSeek
- **Payment**: Alipay/WeChat
- **API**: OpenAI-compatible, supports streaming and tools/function-calling
- **Features**: Competitive pricing, free credits on signup

### Verification
- [x] Added to `data/providers.yaml` (not README — per CONTRIBUTING.md)
- [x] Follows existing YAML schema
- [x] All required fields populated
- [x] Service is publicly accessible at coderplan.ai