### PR TITLE
Add A3M Router - open-source parallel ensemble LLM router

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ market, not a workaround niche.
 | [Atlas Cloud](https://www.atlascloud.ai) | aggregator | Card | Multi-modal aggregator; image/video heavy (Grok Imagine, Kling, ByteDance, Vidu). Public OpenAI-compatible /v1/models endpoint exposes per-token pricing including cache-read. |
 | [Relaydance](https://relaydance.com) | mixed | Alipay/WeChat/Card | 新-API (Calcium-Ion fork) operator focused on xAI Grok + ByteDance Doubao. Public /api/pricing returns ratio-based pricing (model_ratio × $2 / 1M tokens). |
 | [LiteLLM](https://litellm.ai) | gateway-oss | — | Open-source gateway + enterprise tier. Self-hosted; not retail. |
+| [A3M Router](https://github.com/Das-rebel/a3m-router) | gateway-oss | MIT | TypeScript, 47+ providers. Parallel ensemble multi-model LLM router with Shapley value credit allocation, game-theoretic risk profiling, circuit breaker, semantic cache, guardrails. Highest robustness (0.8524) on RouterArena. 19K+ npm downloads. |
 | [Helicone](https://helicone.ai) | observability | — | LLM observability gateway; logging/analytics focus. |
 | [AIMLAPI](https://aimlapi.com) | aggregator | Card/Crypto | Prepaid from $20; crypto support implies payment-friction workaround. |
 <!-- providers:global_gateways:end -->

--- a/data/providers.yaml
+++ b/data/providers.yaml
@@ -354,3 +354,16 @@ self_hosted_alternatives:
       en: "Fork of One-API with extra channel types; same self-hosted model — you supply keys."
       zh-TW: "One-API 的 fork，多了幾種通道類型；同樣自架、自帶 key。"
       zh-CN: "One-API 的 fork，多了几种通道类型；同样自托管、自带 key。"
+
+  - name: A3M Router
+    url: https://github.com/Das-rebel/a3m-router
+    type: gateway-oss
+    status: unverified
+    provider_count: 47
+    last_verified: null
+    verified_by: community
+    entity_registered: false
+    supports_stream: true
+    supports_tools: true
+    notes:
+      en: "TypeScript self-hosted router with parallel ensemble orchestration across 47+ providers, Shapley-value credit allocation, semantic cache, circuit breaker, and guardrails. 15K+ npm downloads (package: adaptive-memory-multi-model-router). OpenAI-compatible."


### PR DESCRIPTION
A3M Router: TypeScript LLM router, 19K+ npm downloads, highest RouterArena robustness (0.8524), 47+ providers, China/Asia compatible.