### PR TITLE
docs: lead with the agent value prop (README + dashboard hero rework)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,36 @@
 
 ![Awesome AI API Proxy — a curated map of AI API relay stations (中轉站), LLM gateways, and OpenAI / Anthropic Claude / Google Gemini / Meta Llama proxy services for developers in China, Taiwan, Southeast Asia, Russia, and the Middle East](assets/ai-api-relay-proxy-banner.jpg)
 
-> **One key. Every model. Anywhere.**
-> A curated, **actively maintained** list of AI API relay / proxy stations
-> ("中轉站"), global LLM gateways, and the tools to evaluate them — with an
-> evidence-based look at why this market exists and where it's risky.
+> **One pricing endpoint for AI agents.** Stop hand-checking 10 relay pricing pages — point your agent here.
+
+### 🤖 For AI agents — three ways to consume
+
+```bash
+# 1) Raw JSON (every relay's prices, full provenance)
+curl https://raw.githubusercontent.com/howardpen9/awesome-ai-api-proxy/main/data/prices.latest.json
+
+# 2) MCP server (Claude Desktop / Cursor / Cline) — auto tool-call from the model
+uvx awesome-ai-api-proxy-mcp
+
+# 3) Interactive dashboard for humans
+open https://howardpen9.github.io/awesome-ai-api-proxy/
+```
+
+**What's inside:** 7 relay fetchers refreshed weekly, ~3000 normalized price records, 6 canonical models on a cost-tier ladder, full provenance per row (`source_url` + `captured_at` + `method`) so agents can cite confidently. See [docs/agent-integration.md](docs/agent-integration.md) for MCP / LangChain / OpenAI function-calling / direct HTTP examples.
+
+---
 
 **Languages:** English · [繁體中文](README.zh-TW.md) · [简体中文](README.zh-CN.md)
 
-Last reviewed: **2026-05-26** · Maintained by [@howardpen9](https://github.com/howardpen9) ·
+Last reviewed: **2026-06-09** · Maintained by [@howardpen9](https://github.com/howardpen9) ·
 Contributions welcome — see [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ---
 
 ## Contents
 
+- [For AI agents & programmatic use](#for-ai-agents--programmatic-use) ← start here
+- [Price snapshot (weekly)](#price-snapshot-weekly)
 - [What is an AI API relay?](#what-is-an-ai-api-relay)
 - [Why this exists (globally)](#why-this-exists-globally)
 - [China / Asia relay stations](#china--asia-relay-stations)
@@ -23,9 +39,7 @@ Contributions welcome — see [CONTRIBUTING.md](CONTRIBUTING.md)
 - [Self-hosted alternatives](#self-hosted-alternatives)
 - [Comparison & monitoring tools](#comparison--monitoring-tools)
 - [Want your relay listed?](#want-your-relay-listed)
-- [Price snapshot (weekly)](#price-snapshot-weekly)
 - [How to choose one safely](#how-to-choose-one-safely)
-- [For AI agents & programmatic use](#for-ai-agents--programmatic-use)
 - [Canary prompts (detect silent downgrade)](#canary-prompts-detect-silent-downgrade)
 - [Risks (read this)](#risks-read-this)
 - [Market context](#market-context)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,17 +1,35 @@
 # Awesome AI API 中转站 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
-> 一份**持续维护**的 AI API 中转站 / 代理（"中转站"）、全球 LLM 网关，
-> 以及评估工具的清单 —— 基于证据，讲清楚这个市场为什么存在、风险在哪。
+> **一个给 AI agent 的价格端点。** 不用再手动打开 10 家中转站的价格页 —— 把 agent 指过来这里。
+
+### 🤖 给 AI agent —— 三种取用方式
+
+```bash
+# 1) 纯 JSON（全部中转站的价格、附完整出处）
+curl https://raw.githubusercontent.com/howardpen9/awesome-ai-api-proxy/main/data/prices.latest.json
+
+# 2) MCP server（Claude Desktop / Cursor / Cline）—— 模型自己会叫 tool
+uvx awesome-ai-api-proxy-mcp
+
+# 3) 给人类看的交互 dashboard
+open https://howardpen9.github.io/awesome-ai-api-proxy/
+```
+
+**内容：**7 个中转站 fetcher 每周自动爬、~3000 条标准化价格、6 个 canonical 模型在 cost-tier ladder 上、每条都带完整出处（`source_url` + `captured_at` + `method`）让 agent 引用得有底气。MCP / LangChain / OpenAI function-calling / 纯 HTTP 范例见 [docs/agent-integration.md](docs/agent-integration.md)。
+
+---
 
 **语言：** [English](README.md) · [繁體中文](README.zh-TW.md) · 简体中文
 
-最后审阅：**2026-05-26** · 维护者 [@howardpen9](https://github.com/howardpen9) ·
+最后审阅：**2026-06-09** · 维护者 [@howardpen9](https://github.com/howardpen9) ·
 欢迎贡献 —— 见 [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ---
 
 ## 目录
 
+- [给 AI agent 与程序化使用](#给-ai-agent-与程序化使用) ← 从这里开始
+- [价格快照（每周更新）](#价格快照每周更新)
 - [什么是 API 中转站](#什么是-api-中转站)
 - [为什么会出现（全球视角）](#为什么会出现全球视角)
 - [中国 / 亚洲中转站](#中国--亚洲中转站)
@@ -19,9 +37,7 @@
 - [自托管替代方案](#自托管替代方案)
 - [对比与监控工具](#对比与监控工具)
 - [想被收录吗？](#想被收录吗)
-- [价格快照（每周更新）](#价格快照每周更新)
 - [如何安全地挑选](#如何安全地挑选)
-- [给 AI agent 与程序化使用](#给-ai-agent-与程序化使用)
 - [Canary 验证 prompt（检测偷偷降智）](#canary-验证-prompt检测偷偷降智)
 - [风险（务必阅读）](#风险务必阅读)
 - [市场背景](#市场背景)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,17 +1,35 @@
 # Awesome AI API 中轉站 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
-> 一份**持續維護**的 AI API 中轉站 / 代理（「中轉站」）、全球 LLM 閘道，
-> 以及評估工具的清單 —— 用證據說清楚這個市場為什麼存在、風險在哪。
+> **一個給 AI agent 的價格端點。** 不用再手動打開 10 家中轉站的價格頁 —— 把 agent 指過來這裡。
+
+### 🤖 給 AI agent —— 三種取用方式
+
+```bash
+# 1) 純 JSON（全部中轉站的價格、附完整出處）
+curl https://raw.githubusercontent.com/howardpen9/awesome-ai-api-proxy/main/data/prices.latest.json
+
+# 2) MCP server（Claude Desktop / Cursor / Cline）—— 模型自己會叫 tool
+uvx awesome-ai-api-proxy-mcp
+
+# 3) 給人類看的互動 dashboard
+open https://howardpen9.github.io/awesome-ai-api-proxy/
+```
+
+**內容：**7 個中轉站 fetcher 每週自動爬、~3000 條標準化價格、6 個 canonical 模型在 cost-tier ladder 上、每筆都帶完整出處（`source_url` + `captured_at` + `method`）讓 agent 可以引用得有底氣。MCP / LangChain / OpenAI function-calling / 純 HTTP 範例見 [docs/agent-integration.md](docs/agent-integration.md)。
+
+---
 
 **語言：** [English](README.md) · 繁體中文 · [简体中文](README.zh-CN.md)
 
-最後審閱：**2026-05-26** · 維護者 [@howardpen9](https://github.com/howardpen9) ·
+最後審閱：**2026-06-09** · 維護者 [@howardpen9](https://github.com/howardpen9) ·
 歡迎貢獻 —— 見 [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ---
 
 ## 目錄
 
+- [給 AI agent 與程式化使用](#給-ai-agent-與程式化使用) ← 從這裡開始
+- [價格快照（每週更新）](#價格快照每週更新)
 - [什麼是 API 中轉站](#什麼是-api-中轉站)
 - [為什麼會出現（全球視角）](#為什麼會出現全球視角)
 - [中國 / 亞洲中轉站](#中國--亞洲中轉站)
@@ -19,9 +37,7 @@
 - [自架替代方案](#自架替代方案)
 - [對比與監控工具](#對比與監控工具)
 - [想被收錄嗎？](#想被收錄嗎)
-- [價格快照（每週更新）](#價格快照每週更新)
 - [如何安全地挑選](#如何安全地挑選)
-- [給 AI agent 與程式化使用](#給-ai-agent-與程式化使用)
 - [Canary 驗證 prompt（偵測偷偷降智）](#canary-驗證-prompt偵測偷偷降智)
 - [風險（務必閱讀）](#風險務必閱讀)
 - [市場背景](#市場背景)

--- a/docs/index.html
+++ b/docs/index.html
@@ -52,6 +52,39 @@
     }
     .chart { background: var(--card); border: 1px solid var(--border); border-radius: 12px;
              padding: 8px; margin-bottom: 24px; min-height: 380px; }
+    .agent-hero {
+      background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 12%, transparent),
+                                              color-mix(in srgb, var(--accent) 3%, transparent));
+      border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+      border-radius: 16px; padding: 20px 24px; margin: 24px 0 8px;
+    }
+    .agent-hero h2 { margin: 0 0 4px; padding: 0; border: 0; font-size: 1.15rem; color: var(--accent); }
+    .agent-hero p.tagline { margin: 0 0 16px; color: var(--muted); font-size: 0.95rem; }
+    .copy-row { display: flex; align-items: center; gap: 8px; margin: 10px 0;
+                background: var(--bg); padding: 6px 6px 6px 12px; border-radius: 8px;
+                border: 1px solid var(--border); }
+    .copy-row code { flex: 1; font-size: 0.82rem; overflow-x: auto;
+                     white-space: nowrap; padding: 4px 0; }
+    .copy-row button {
+      background: var(--accent); color: white; border: 0; padding: 6px 14px;
+      border-radius: 6px; cursor: pointer; font-size: 0.82rem; white-space: nowrap;
+    }
+    .copy-row button:hover { opacity: 0.9; }
+    .copy-row button.copied { background: #10b981; }
+    details.mcp-config { margin-top: 8px; }
+    details.mcp-config summary { cursor: pointer; padding: 4px 0; color: var(--muted); font-size: 0.88rem; }
+    details.mcp-config pre {
+      background: var(--bg); border: 1px solid var(--border); border-radius: 8px;
+      padding: 10px 14px; font-size: 0.78rem; overflow-x: auto; margin: 8px 0 0;
+    }
+    .human-divider {
+      text-align: center; margin: 32px 0 8px; color: var(--muted); font-size: 0.9rem;
+      position: relative;
+    }
+    .human-divider::before, .human-divider::after {
+      content: ""; display: inline-block; width: 80px; height: 1px;
+      background: var(--border); vertical-align: middle; margin: 0 12px;
+    }
     table { width: 100%; border-collapse: collapse; font-size: 0.88rem; }
     th, td { padding: 8px 10px; text-align: left; border-bottom: 1px solid var(--border); }
     th { background: var(--card); position: sticky; top: 0; font-weight: 600; }
@@ -68,13 +101,51 @@
   <main>
     <h1>AI API Relay Price Observatory</h1>
     <p class="lead">
-      Weekly normalized snapshots of AI API relay station and LLM gateway prices.
+      <strong>One pricing endpoint for AI agents.</strong>
+      Stop hand-checking 10 relay pricing pages — point your agent here.
+    </p>
+
+    <section class="agent-hero" aria-label="For AI agents">
+      <h2>🤖 For AI agents</h2>
+      <p class="tagline">One URL = every relay's prices, full provenance, refreshed weekly.</p>
+
+      <div class="copy-row">
+        <code id="raw-url">https://raw.githubusercontent.com/howardpen9/awesome-ai-api-proxy/main/data/prices.latest.json</code>
+        <button data-copy="raw-url">Copy URL</button>
+      </div>
+
+      <div class="copy-row">
+        <code id="curl-cmd">curl https://raw.githubusercontent.com/howardpen9/awesome-ai-api-proxy/main/data/prices.latest.json</code>
+        <button data-copy="curl-cmd">Copy curl</button>
+      </div>
+
+      <details class="mcp-config">
+        <summary>Claude Desktop / Cursor / Cline (MCP) — model auto-calls the tool</summary>
+        <pre id="mcp-config">{
+  "mcpServers": {
+    "awesome-ai-api-proxy": {
+      "command": "uvx",
+      "args": ["awesome-ai-api-proxy-mcp"]
+    }
+  }
+}</pre>
+        <div class="copy-row">
+          <code style="white-space: pre-wrap;">uvx awesome-ai-api-proxy-mcp</code>
+          <button data-copy="mcp-config">Copy config</button>
+        </div>
+      </details>
+    </section>
+
+    <div class="meta" id="meta">Loading <code>data/prices.latest.json</code>…</div>
+
+    <div class="human-divider">👀 For humans — explore the data below</div>
+
+    <p class="lead" style="margin-top: 8px;">
       <strong class="warn">⚠</strong> = relay quotes <50% of OpenRouter (the
       official-authorized reference baseline) — verify with
       <a href="https://github.com/howardpen9/awesome-ai-api-proxy/blob/main/docs/canary-prompts.md">canary prompts</a>
       before trusting.
     </p>
-    <div class="meta" id="meta">Loading <code>data/prices.latest.json</code>…</div>
 
     <div class="controls" role="tablist" aria-label="Pricing unit">
       <button data-unit="per_1m_input_tokens" aria-pressed="true">Input tokens (per 1M)</button>
@@ -312,6 +383,24 @@
   });
   document.getElementById("search").addEventListener("input", e => {
     renderTable(e.target.value);
+  });
+
+  // Agent-hero copy buttons
+  document.querySelectorAll("[data-copy]").forEach(btn => {
+    btn.addEventListener("click", async () => {
+      const target = document.getElementById(btn.dataset.copy);
+      if (!target) return;
+      try {
+        await navigator.clipboard.writeText(target.textContent.trim());
+        const orig = btn.textContent;
+        btn.textContent = "✓ Copied";
+        btn.classList.add("copied");
+        setTimeout(() => { btn.textContent = orig; btn.classList.remove("copied"); }, 1500);
+      } catch (e) {
+        btn.textContent = "Press Cmd+C";
+        setTimeout(() => { btn.textContent = "Copy"; }, 1500);
+      }
+    });
   });
 
   load();


### PR DESCRIPTION
## Summary

Reorders both the README and the GitHub Pages dashboard so the **first-fold = "point your AI agent here, stop hand-checking 10 relay pricing pages"** — the actual value prop of this repo. Before this PR, the agent-integration section was at TOC position 10/16 (buried). The dashboard's first content block was a Plotly chart for humans; the raw URL / MCP install was in the footer.

## Changes

**README** (en/zh-TW/zh-CN):
- New tagline: *"One pricing endpoint for AI agents."*
- Fenced code block at top with **three ways to consume** — `curl` raw JSON, `uvx` MCP server, `open` interactive dashboard
- TOC reordered: "For AI agents" + "Price snapshot" jump to the top

**Dashboard** (`docs/index.html`):
- New `.agent-hero` gradient-tinted block above the controls/charts with:
  - Copy-to-clipboard button for the raw `prices.latest.json` URL
  - Copy `curl` one-liner
  - Collapsible `<details>` with the Claude Desktop MCP config + `uvx` install
- Visual divider `👀 For humans — explore the data below` separating the agent section from the existing tier chart + heatmap + records table

## Scope discipline

Presentation only. **No changes to:** data, schemas, fetchers, workflows, validate, build_prices. Other v1.6 polish items (risk_flags, status emoji + legend, benchmark refs, PR #9 FerryAPI triage) ship separately.

## Test plan

- [x] All 3 READMEs render correctly (verified markdown + TOC links)
- [x] Dashboard loads on local file open + copy buttons work (clipboard API)
- [ ] Verify on GH Pages once merged: https://howardpen9.github.io/awesome-ai-api-proxy/
- [ ] Verify mobile responsive (the copy-row uses flex; long URL should overflow-scroll, not break layout)

## Follow-ups (not in this PR)

- Dashboard `["openrouter", "atlascloud", "relaydance"]` hardcoded list in the heatmap render still misses uiuiapi/bltcy/unorouter — separate PR
- `risk_flags` + `🟢/🟡/🔴` status emoji + legend
- Benchmark refs (tbench / kilo / arena) — README link + canonical-models.yaml field
- Triage PR #9 (FerryAPI) after risk_flags ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)