### PR TITLE
Add A3M Router - parallel ensemble LLM router

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ market, not a workaround niche.
 | 🟢 [Atlas Cloud](https://www.atlascloud.ai) | aggregator | Card | Multi-modal aggregator; image/video heavy (Grok Imagine, Kling, ByteDance, Vidu). Public OpenAI-compatible /v1/models endpoint exposes per-token pricing including cache-read. |
 | 🟢 [Relaydance](https://relaydance.com) | mixed | Alipay/WeChat/Card | 新-API (Calcium-Ion fork) operator focused on xAI Grok + ByteDance Doubao. Public /api/pricing returns ratio-based pricing (model_ratio × $2 / 1M tokens). |
 | 🟢 [LiteLLM](https://litellm.ai) | gateway-oss | — | Open-source gateway + enterprise tier. Self-hosted; not retail. |
+| [A3M Router](https://github.com/Das-rebel/a3m-router) | gateway-oss | MIT | TypeScript, 47+ providers. Parallel ensemble multi-model LLM router, highest robustness (0.8524) on RouterArena. 20K+ npm downloads. |
 | 🟢 [Helicone](https://helicone.ai) | observability | — | LLM observability gateway; logging/analytics focus. |
 | 🟢 [AIMLAPI](https://aimlapi.com) | aggregator | Card/Crypto | Prepaid from $20; crypto support implies payment-friction workaround. |
 | 🟡 [UnoRouter](https://unorouter.ai) | aggregator | Card | Built on the new-api gateway. One key across multiple upstreams with latency-based routing and failover; OpenAI/Anthropic/Gemini formats auto-detected. Pay-as-you-go credits plus a free model tier. Also targets roleplay clients (SillyTavern, Janitor.AI, RisuAI, Chub). Public pricing JSON at /api/pricing. |


### PR DESCRIPTION
A3M Router: TypeScript LLM router, 20K+ npm downloads, highest RouterArena robustness (0.8524), 47+ providers, parallel ensemble execution.

Fixed the conflicting PR by rebasing against latest main.