### PR TITLE
add: Prism API relay

### DIFF
--- a/data/providers.yaml
+++ b/data/providers.yaml
@@ -106,6 +106,21 @@ china_relays:
       zh-TW: "宣稱官方渠道 + 官方倍率；約便宜 49%（宣稱），311 模型。new-api `/api/pricing` 公開於 api1 子網域。"
       zh-CN: "宣称官方渠道 + 官方倍率；约便宜 49%（宣称），311 模型。new-api `/api/pricing` 公开于 api1 子域名。"
 
+  - name: Prism API (棱镜API)
+    url: https://sub2api.558686.xyz
+    type: mixed
+    status: unverified
+    payment: [crypto]
+    models: [openai]
+    last_verified: null
+    verified_by: community
+    entity_registered: unknown
+    supports_stream: unknown
+    supports_tools: unknown
+    risk_flags: [operator_submitted, no_entity]
+    notes:
+      en: "Operator-submitted OpenAI-focused relay; crypto top-up via BEpusdt/EasyPay and Google signup grants are shown on the public site."
+
   - name: DMXAPI
     url: https://dmxapi.cn
     type: mixed


### PR DESCRIPTION
﻿## What this changes

Adds Prism API (棱镜API) as an operator-submitted, unverified OpenAI-focused relay entry.

## Checklist

- [x] Edited `data/providers.yaml` only (not the README tables - they auto-regenerate)
- [x] Followed [`data/schema.md`](../data/schema.md)
- [x] `status: unverified` if I cannot independently verify (self-submissions default to this)
- [x] No referral / affiliate links, no marketing copy
- [x] `notes` is one factual sentence
- [x] Claims have a dated source where non-obvious
- [x] If adding a price fetcher: not applicable

## Source / verification

Public site checked on 2026-06-24: https://sub2api.558686.xyz/ resolves and shows the relay UI. The listing is marked `operator_submitted` and `unverified`; payment/model details are limited to what the public site exposes.

## Are you the operator of this station? (Optional)

Yes, operator-submitted for transparency.
