### PR TITLE
添加 cocodot(支付宝直充 · 官转 · 支持 Claude Code 直连 · 可验真)

### DIFF
--- a/data/providers.yaml
+++ b/data/providers.yaml
@@ -173,6 +173,20 @@ china_relays:
       zh-TW: "提供對公發票；自稱亞洲最大企業級中轉。"
       zh-CN: "提供对公发票；自称亚洲最大企业级中转。"
 
+  - name: cocodot
+    url: https://cocodot.co
+    type: official-relay
+    status: active
+    payment: [alipay, card]
+    models: [openai, anthropic, gemini, deepseek]
+    entity_registered: true
+    supports_stream: true
+    supports_tools: true
+    notes:
+      en: "Alipay top-up, per-token billing capped at official prices; Anthropic-compatible endpoint so Claude Code can connect directly (beta); ships open-source LLMprobe for model-downgrade self-testing."
+      zh-TW: "支付寶充值、按量計費、封頂不超官網價；另有 Anthropic 相容端點，Claude Code 可直連（beta）；開源 LLMprobe 可自測降智。"
+      zh-CN: "支付宝充值、按量计费、封顶不超官网价；另有 Anthropic 兼容端点，Claude Code 可直连（beta）；开源 LLMprobe 可自测降智。"
+
 # ---------------------------------------------------------------------------
 # Comparison / monitoring tools (中轉站對比工具)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
添加 cocodot(https://cocodot.co):

- 支付宝人民币充值,按量计费,封顶不超官网价(主流模型官网9折起)
- 海外注册公司运营,走持牌云厂商官转(非逆向)
- OpenAI 兼容 + Anthropic 兼容端点(Claude Code 可直连,beta)
- 开源工具 LLMprobe 可自测模型不降智,方法公开:https://cocodot.co/trust

感谢维护这份清单!