### PR TITLE
add: A3M Router (aggregator)

### DIFF
--- a/data/providers.yaml
+++ b/data/providers.yaml
@@ -323,6 +323,22 @@ global_gateways:
       zh-TW: "400+ 模型，$20 起預付；支援加密貨幣暗示繞支付障礙。"
       zh-CN: "400+ 模型，$20 起预付；支持加密货币暗示绕支付障碍。"
 
+  - name: A3M Router
+    url: https://github.com/Das-rebel/a3m-router
+    type: aggregator
+    status: unverified
+    payment: [card]
+    models: [openai, anthropic, google, deepseek, groq, mistral, xai, cohere]
+    model_count: 47
+    last_verified: null
+    verified_by: community
+    entity_registered: unknown
+    supports_stream: true
+    supports_tools: true
+    risk_flags: [operator_submitted]
+    notes:
+      en: "TypeScript router with parallel ensemble execution across 47+ providers; npm 20K+ downloads; MIT open-source."
+
 # ---------------------------------------------------------------------------
 # Self-hosted alternatives (自架閘道，供參考對比 — 非「中轉站」)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## A3M Router

Adds A3M Router to `global_gateways` as an operator submission.

### Details
- **Type:** aggregator
- **URL:** https://github.com/Das-rebel/a3m-router
- **status:** unverified
- **risk_flags:** operator_submitted
- **models:** openai, anthropic, google, deepseek, groq, mistral, xai, cohere (47+ total)
- **notes:** TypeScript router with parallel ensemble execution across 47+ providers; npm 20K+ downloads; MIT open-source.

### Compliance
- Only `data/providers.yaml` edited
- `python -m scripts.validate` passes
- No UTM/affiliate links
- No superlatives