### PR TITLE
add: A3M Router as self-hosted gateway-oss (#38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ templates.
 |---|---|---|
 | 🟢 [One-API](https://github.com/songquanpeng/one-api) | gateway-oss | Popular Go-based self-hosted multi-vendor gateway; the de-facto OSS template behind many relay stations. |
 | 🟢 [new-api](https://github.com/Calcium-Ion/new-api) | gateway-oss | Fork of One-API with extra channel types; same self-hosted model — you supply keys. |
+| 🟡 [A3M Router](https://github.com/Das-rebel/a3m-router) | gateway-oss | MIT TypeScript OpenAI-compatible multi-provider router (parallel ensemble); self-hosted — you supply keys. npm: adaptive-memory-multi-model-router. |
 <!-- providers:self_hosted_alternatives:end -->
 
 > [LiteLLM](https://litellm.ai) (in the global table above) is also self-hosted (Python, 100+ providers, used by enterprises).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -128,6 +128,7 @@ OpenAI、Anthropic、Google 等官方 API，而是把 `base_url` 改成中转站
 |---|---|---|
 | 🟢 [One-API](https://github.com/songquanpeng/one-api) | gateway-oss | 流行的 Go 多厂商网关；多数中转站的底层 OSS 模板。 |
 | 🟢 [new-api](https://github.com/Calcium-Ion/new-api) | gateway-oss | One-API 的 fork，多了几种通道类型；同样自托管、自带 key。 |
+| 🟡 [A3M Router](https://github.com/Das-rebel/a3m-router) | gateway-oss | MIT TypeScript OpenAI-compatible multi-provider router (parallel ensemble); self-hosted — you supply keys. npm: adaptive-memory-multi-model-router. |
 <!-- providers:self_hosted_alternatives:end -->
 
 > [LiteLLM](https://litellm.ai)（在上面海外网关表格内）同样是自托管方案（Python 为主、100+ 供应商、企业常用）。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -128,6 +128,7 @@ OpenAI、Anthropic、Google 等官方 API，而是把 `base_url` 改成中轉站
 |---|---|---|
 | 🟢 [One-API](https://github.com/songquanpeng/one-api) | gateway-oss | 流行的 Go 多廠商閘道；多數中轉站的底層 OSS 模板。 |
 | 🟢 [new-api](https://github.com/Calcium-Ion/new-api) | gateway-oss | One-API 的 fork，多了幾種通道類型；同樣自架、自帶 key。 |
+| 🟡 [A3M Router](https://github.com/Das-rebel/a3m-router) | gateway-oss | MIT TypeScript OpenAI-compatible multi-provider router (parallel ensemble); self-hosted — you supply keys. npm: adaptive-memory-multi-model-router. |
 <!-- providers:self_hosted_alternatives:end -->
 
 > [LiteLLM](https://litellm.ai)（在上面海外閘道表格內）同樣是自架方案（Python 為主、100+ 供應商、企業常用）。

--- a/data/providers.yaml
+++ b/data/providers.yaml
@@ -410,3 +410,20 @@ self_hosted_alternatives:
       en: "Fork of One-API with extra channel types; same self-hosted model — you supply keys."
       zh-TW: "One-API 的 fork，多了幾種通道類型；同樣自架、自帶 key。"
       zh-CN: "One-API 的 fork，多了几种通道类型；同样自托管、自带 key。"
+
+  # Landed from PR #38 (Das-rebel) after reclassifying as self-hosted BYOK
+  # gateway-oss (not a retail hosted aggregator).
+  - name: A3M Router
+    url: https://github.com/Das-rebel/a3m-router
+    type: gateway-oss
+    status: unverified
+    models: [openai, anthropic, google, deepseek, groq, mistral, xai, cohere]
+    provider_count: 47
+    last_verified: null
+    verified_by: community
+    entity_registered: unknown
+    supports_stream: unknown
+    supports_tools: unknown
+    risk_flags: [operator_submitted]
+    notes:
+      en: "MIT TypeScript OpenAI-compatible multi-provider router (parallel ensemble); self-hosted — you supply keys. npm: adaptive-memory-multi-model-router."


### PR DESCRIPTION
## Summary
- Lands [PR #38](https://github.com/howardpen9/awesome-ai-api-proxy/pull/38) from @Das-rebel with maintainer category fix.
- **Section:** `self_hosted_alternatives` (peers One-API / new-api)
- **Type:** `gateway-oss` (self-hosted BYOK, not hosted aggregator)
- `status: unverified` + `risk_flags: [operator_submitted]`
- Regenerated README tables via `build_provider_tables`

## Why not merge #38 as-is
- Was under `global_gateways` + `type: aggregator` + `payment: [card]` — misleads readers looking for prepaid relays.
- Notes claimed generic "npm 20K+ downloads"; package is `adaptive-memory-multi-model-router`.

## Test plan
- [x] `python -m scripts.validate`
- [x] A3M appears under self-hosted section in all 3 READMEs
- [ ] CI validate + links

Closes #38