### PR TITLE
Add QuickSilver Pro (Global gateways & aggregators)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ market, not a workaround niche.
 | 🟢 [AIMLAPI](https://aimlapi.com) | aggregator | Card/Crypto | Prepaid from $20; crypto support implies payment-friction workaround. |
 | 🟡 [RouteScope](https://www.routescope.ai) | aggregator | Card/Crypto | Unified gateway mapping 100+ models to OpenAI/Claude/Gemini-compatible APIs; pay-as-you-go credits. |
 | 🟡 [UnoRouter](https://unorouter.ai) | aggregator | Card | Built on the new-api gateway. One key across multiple upstreams with latency-based routing and failover; OpenAI/Anthropic/Gemini formats auto-detected. Pay-as-you-go credits plus a free model tier. Also targets roleplay clients (SillyTavern, Janitor.AI, RisuAI, Chub). Public pricing JSON at /api/pricing. |
+| 🟡 [QuickSilver Pro](https://quicksilverpro.io) | aggregator | Card | OpenAI-compatible gateway; one key for frontier and open models (Claude, GPT, Gemini, DeepSeek, Qwen, Kimi, GLM). Pay-as-you-go, no subscription. Public pricing JSON at /pricing.json. Operated by MachineFi Labs. |
 <!-- providers:global_gateways:end -->
 
 ## Self-hosted alternatives

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -115,6 +115,7 @@ OpenAI、Anthropic、Google 等官方 API，而是把 `base_url` 改成中转站
 | 🟢 [AIMLAPI](https://aimlapi.com) | aggregator | 卡/加密货币 | 400+ 模型，$20 起预付；支持加密货币暗示绕支付障碍。 |
 | 🟡 [RouteScope](https://www.routescope.ai) | aggregator | 卡/加密货币 | 统一网关，将 100+ 模型转成 OpenAI／Claude／Gemini 兼容 API；按量预付额度。 |
 | 🟡 [UnoRouter](https://unorouter.ai) | aggregator | 卡 | 建于 new-api 网关之上。单一密钥跨多上游，按延迟路由并具故障转移；自动识别 OpenAI／Anthropic／Gemini 格式。按量计费并提供免费模型层；亦支持角色扮演客户端（SillyTavern、Janitor.AI、RisuAI、Chub）。 |
+| 🟡 [QuickSilver Pro](https://quicksilverpro.io) | aggregator | 卡 | OpenAI-compatible gateway; one key for frontier and open models (Claude, GPT, Gemini, DeepSeek, Qwen, Kimi, GLM). Pay-as-you-go, no subscription. Public pricing JSON at /pricing.json. Operated by MachineFi Labs. |
 <!-- providers:global_gateways:end -->
 
 ## 自托管替代方案

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -115,6 +115,7 @@ OpenAI、Anthropic、Google 等官方 API，而是把 `base_url` 改成中轉站
 | 🟢 [AIMLAPI](https://aimlapi.com) | aggregator | 卡/加密貨幣 | 400+ 模型，$20 起預付；支援加密貨幣暗示繞支付障礙。 |
 | 🟡 [RouteScope](https://www.routescope.ai) | aggregator | 卡/加密貨幣 | 統一閘道，將 100+ 模型轉成 OpenAI／Claude／Gemini 相容 API；按量預付額度。 |
 | 🟡 [UnoRouter](https://unorouter.ai) | aggregator | 卡 | 建於 new-api 閘道之上。單一金鑰跨多上游，依延遲路由並具故障轉移；自動辨識 OpenAI／Anthropic／Gemini 格式。按量計費並提供免費模型層；亦支援角色扮演用戶端（SillyTavern、Janitor.AI、RisuAI、Chub）。 |
+| 🟡 [QuickSilver Pro](https://quicksilverpro.io) | aggregator | 卡 | OpenAI-compatible gateway; one key for frontier and open models (Claude, GPT, Gemini, DeepSeek, Qwen, Kimi, GLM). Pay-as-you-go, no subscription. Public pricing JSON at /pricing.json. Operated by MachineFi Labs. |
 <!-- providers:global_gateways:end -->
 
 ## 自架替代方案

--- a/data/providers.yaml
+++ b/data/providers.yaml
@@ -379,6 +379,23 @@ global_gateways:
       zh-TW: "建於 new-api 閘道之上。單一金鑰跨多上游，依延遲路由並具故障轉移；自動辨識 OpenAI／Anthropic／Gemini 格式。按量計費並提供免費模型層；亦支援角色扮演用戶端（SillyTavern、Janitor.AI、RisuAI、Chub）。"
       zh-CN: "建于 new-api 网关之上。单一密钥跨多上游，按延迟路由并具故障转移；自动识别 OpenAI／Anthropic／Gemini 格式。按量计费并提供免费模型层；亦支持角色扮演客户端（SillyTavern、Janitor.AI、RisuAI、Chub）。"
 
+  - name: QuickSilver Pro
+    url: https://quicksilverpro.io
+    type: aggregator
+    status: unverified
+    payment: [card]
+    models: [openai, anthropic, gemini, deepseek, qwen, moonshotai, zhipuai, minimax, meta, xai]
+    model_count: 35
+    discount_vs_official: "~20% below OpenRouter on comparable models (claimed)"
+    last_verified: null
+    verified_by: community
+    entity_registered: true
+    supports_stream: true
+    supports_tools: true
+    risk_flags: [operator_submitted]
+    notes:
+      en: "OpenAI-compatible gateway; one key for frontier and open models (Claude, GPT, Gemini, DeepSeek, Qwen, Kimi, GLM). Pay-as-you-go, no subscription. Public pricing JSON at /pricing.json. Operated by MachineFi Labs."
+
 # ---------------------------------------------------------------------------
 # Self-hosted alternatives (自架閘道，供參考對比 — 非「中轉站」)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds **QuickSilver Pro** (https://quicksilverpro.io) to *Global gateways & aggregators*, alongside OpenRouter / AIMLAPI / Atlas Cloud.

**Operator self-submission** — flagged `operator_submitted`, `status: unverified` until a maintainer canaries it.

- OpenAI-compatible gateway (`https://api.quicksilverpro.io/v1`), one key for frontier + open models (Claude, GPT, Gemini, DeepSeek, Qwen, Kimi, GLM).
- Pay-as-you-go, card, registered entity (MachineFi Labs).
- Public pricing JSON: https://quicksilverpro.io/pricing.json
- `python -m scripts.validate` → all validations passed; `build_provider_tables` regenerated the READMEs (en text falls back into zh READMEs; happy to add zh-TW/zh-CN notes if you'd like).