### PR TITLE
Add China AI Arbitrage to comparison_tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ You give up the relay's Alipay/WeChat convenience and accept ops overhead.
 |---|---|
 | 🟢 [中轉站競技場 (AI API PK)](https://www.aiapipk.com) | Price wall across OpenAI / Reverse / Claude / DeepSeek for ~40 stations. |
 | 🔴 [awesome-ai-proxy (mn-api, unmaintained)](https://github.com/mn-api/awesome-ai-proxy) | Original list (~31 stations); no longer maintained as of 2026. |
+| 🟡 [China AI Arbitrage](https://www.china-ai-arbitrage.xyz/) | Price & quota comparison of 60+ Chinese AI platforms, ranked 95 LLM API relays, daily-updated free-tier tracking. |
 | 🟡 [CoderPlan](https://coderplan.ai) | Community-submitted; claims 50+ models incl. OpenAI/Anthropic/Google/DeepSeek/xAI. |
 <!-- providers:comparison_tools:end -->
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -143,6 +143,7 @@ OpenAI、Anthropic、Google 等官方 API，而是把 `base_url` 改成中转站
 |---|---|
 | 🟢 [中轉站競技場 (AI API PK)](https://www.aiapipk.com) | 约 40 家站点的 OpenAI / 逆向 / Claude / DeepSeek 报价墙。 |
 | 🔴 [awesome-ai-proxy (mn-api, unmaintained)](https://github.com/mn-api/awesome-ai-proxy) | 最早的清单（约 31 家）。**2026 年起已停更** —— 本仓库延续这一工作。 |
+| 🟡 [China AI Arbitrage](https://www.china-ai-arbitrage.xyz/) | 60+ 中国 AI 平台的价格与额度比价、95 个 LLM API 中转站排名、每日更新的免费额度追踪。 |
 | 🟡 [CoderPlan](https://coderplan.ai) | 社区投稿；宣称 50+ 模型，含 OpenAI/Anthropic/Google/DeepSeek/xAI。 |
 <!-- providers:comparison_tools:end -->
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -143,6 +143,7 @@ OpenAI、Anthropic、Google 等官方 API，而是把 `base_url` 改成中轉站
 |---|---|
 | 🟢 [中轉站競技場 (AI API PK)](https://www.aiapipk.com) | 約 40 家站點的 OpenAI / 逆向 / Claude / DeepSeek 報價牆。 |
 | 🔴 [awesome-ai-proxy (mn-api, unmaintained)](https://github.com/mn-api/awesome-ai-proxy) | 最早的清單（約 31 家）。**2026 年起已停更** —— 本倉庫延續這項工作。 |
+| 🟡 [China AI Arbitrage](https://www.china-ai-arbitrage.xyz/) | 60+ 中國 AI 平台的價格與額度比價、95 個 LLM API 中轉站排名、每日更新的免費額度追蹤。 |
 | 🟡 [CoderPlan](https://coderplan.ai) | 社群投稿；宣稱 50+ 模型，含 OpenAI/Anthropic/Google/DeepSeek/xAI。 |
 <!-- providers:comparison_tools:end -->
 

--- a/data/providers.yaml
+++ b/data/providers.yaml
@@ -199,6 +199,17 @@ comparison_tools:
       zh-TW: "最早的清單（約 31 家）。**2026 年起已停更** —— 本倉庫延續這項工作。"
       zh-CN: "最早的清单（约 31 家）。**2026 年起已停更** —— 本仓库延续这一工作。"
 
+  - name: China AI Arbitrage
+    url: https://www.china-ai-arbitrage.xyz/
+    type: comparison
+    status: unverified
+    last_verified: null
+    verified_by: community
+    notes:
+      en: "Price & quota comparison of 60+ Chinese AI platforms, ranked 95 LLM API relays, daily-updated free-tier tracking."
+      zh-TW: "60+ 中國 AI 平台的價格與額度比價、95 個 LLM API 中轉站排名、每日更新的免費額度追蹤。"
+      zh-CN: "60+ 中国 AI 平台的价格与额度比价、95 个 LLM API 中转站排名、每日更新的免费额度追踪。"
+
 # ---------------------------------------------------------------------------
 # Global gateways / aggregators (海外對比方案)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adding a community comparison site to comparison_tools.

**China AI Arbitrage** (https://www.china-ai-arbitrage.xyz/)
- Price & quota comparison of 60+ Chinese AI platforms (GLM / Kimi / Tongyi / Doubao etc.)
- Ranked directory of 95 LLM API relay stations
- Daily-updated free-tier / free-token tracking

Changes follow CONTRIBUTING.md: edited data/providers.yaml only (status: unverified, verified_by: community), then regenerated the three READMEs via scripts/build_provider_tables.py.

Site operator note: we are the site operator submitting ourselves (risk_flag operator_self equivalent); happy to be canaried/verified by a maintainer.