### PR TITLE
add: community stations from open issues/PRs (#22–#54, #52, #53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ market, not a workaround niche.
 | 🟡 [MKEAI](https://mkeai.com) | mixed | Alipay/WeChat | unverified · ⚠ no-entity | Community-forum + relay hybrid; pushes DeepSeek heavily. |
 | 🟡 [GPTGOD](https://gptgod.online) | reverse | Alipay | unverified · ⚠ reverse, no-entity | Reverse-engineered; among cheapest, stability not guaranteed. |
 | 🟢 [CloseAI](https://www.closeai-asia.com) | official-relay | Alipay/WeChat/Invoice | active · 2026-05-26 · registered | Issues enterprise invoices; self-describes as largest enterprise-grade relay in Asia. |
+| 🟡 [玄枢API (XuanShu API)](https://www.xuanshuapi.com) | mixed | Invoice | unverified · ⚠ operator-self | Serves Anthropic Messages and Gemini v1beta at the root host and OpenAI Responses and Chat Completions under /v1; model visibility and pricing are per-key and per-group, set in the console. |
+| 🟡 [TeamoRouter](https://teamorouter.com) | mixed | Alipay/WeChat | unverified · ⚠ operator-self | OpenAI / Anthropic / Gemini-compatible gateway; Alipay and WeChat; operator-claimed multi-upstream routing and Claude Code / Codex setup guides. |
+| 🟡 [wawazz.xyz](https://wawazz.xyz) | mixed | WeChat | unverified · ⚠ operator-self, cheap-trap | OpenAI-compatible API at /v1; WeChat pay; operator-claimed GPT pricing as low as 0.07x official. |
+| 🟡 [Wappkit API](https://api.wappkit.com) | mixed | — | unverified · ⚠ operator-self | new-api OpenAI-compatible gateway with public /api/pricing; listed groups are Codex/Claude-Code pools (no flat default group). |
 <!-- providers:china_relays:end -->
 
 > **Inclusion ≠ endorsement.** Listing documents the market. Always run the
@@ -122,6 +126,12 @@ market, not a workaround niche.
 | 🟢 [AIMLAPI](https://aimlapi.com) | aggregator | Card/Crypto | Prepaid from $20; crypto support implies payment-friction workaround. |
 | 🟡 [RouteScope](https://www.routescope.ai) | aggregator | Card/Crypto | Unified gateway mapping 100+ models to OpenAI/Claude/Gemini-compatible APIs; pay-as-you-go credits. |
 | 🟡 [UnoRouter](https://unorouter.ai) | aggregator | Card | Built on the new-api gateway. One key across multiple upstreams with latency-based routing and failover; OpenAI/Anthropic/Gemini formats auto-detected. Pay-as-you-go credits plus a free model tier. Also targets roleplay clients (SillyTavern, Janitor.AI, RisuAI, Chub). Public pricing JSON at /api/pricing. |
+| 🟡 [QuickSilver Pro](https://quicksilverpro.io) | aggregator | Card | OpenAI-compatible gateway; one key for frontier and open models (Claude, GPT, Gemini, DeepSeek, Qwen, Kimi, GLM). Pay-as-you-go. Public pricing JSON at /pricing.json. Operated by MachineFi Labs (claimed). |
+| 🟡 [NovAI](https://aiapi-pro.com) | aggregator | Card/Crypto | OpenAI-compatible aggregator for Chinese frontier models (DeepSeek, Qwen, GLM, Kimi, MiniMax, Doubao, Hunyuan) plus image and video generation on one /v1 endpoint; public model list at /v1/models, per-token prices on the pricing page. |
+| 🟡 [SandBase](https://sandbase.ai) | aggregator | Card | Unified API with OpenAI-compatible endpoints for multiple model providers, plus tool APIs and managed agents. Operator did not personally verify the live API. |
+| 🟡 [AllRouter](https://allrouter.ai) | aggregator | Alipay/WeChat | OpenAI and Anthropic-compatible aggregator; Alipay and WeChat accepted; operator-claimed Kimi K3 at official Moonshot list price. |
+| 🟡 [AI Router](https://ai-router.dev) | mixed | Card/Crypto/Alipay/WeChat | OpenAI-compatible ChatGPT API relay at api.ai-router.dev/v1 with dashboard API keys, usage tracking, daily/weekly packages, and localized English/Chinese/Russian/Persian pages. |
+| 🟡 [Tokens Forge](https://tokens-forge.com) | aggregator | Card/WeChat | OpenAI-compatible multi-model API gateway with separate official credit and routed wallet balances for GPT, Claude, and Gemini-style models. |
 <!-- providers:global_gateways:end -->
 
 ## Self-hosted alternatives
@@ -153,6 +163,7 @@ You give up the relay's Alipay/WeChat convenience and accept ops overhead.
 |---|---|
 | 🟢 [中轉站競技場 (AI API PK)](https://www.aiapipk.com) | Price wall across OpenAI / Reverse / Claude / DeepSeek for ~40 stations. |
 | 🔴 [awesome-ai-proxy (mn-api, unmaintained)](https://github.com/mn-api/awesome-ai-proxy) | Original list (~31 stations); no longer maintained as of 2026. |
+| 🟡 [China AI Arbitrage](https://www.china-ai-arbitrage.xyz) | Price and quota comparison of 60+ Chinese AI platforms, ranked LLM API relays, and daily-updated free-tier tracking. |
 | 🟡 [CoderPlan](https://coderplan.ai) | Community-submitted; claims 50+ models incl. OpenAI/Anthropic/Google/DeepSeek/xAI. |
 <!-- providers:comparison_tools:end -->
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -97,6 +97,10 @@ OpenAI、Anthropic、Google 等官方 API，而是把 `base_url` 改成中转站
 | 🟡 [MKEAI](https://mkeai.com) | mixed | 支付宝/微信 | unverified · ⚠ 无主体 | 社区论坛 + 中转混合；主推 DeepSeek。 |
 | 🟡 [GPTGOD](https://gptgod.online) | reverse | 支付宝 | unverified · ⚠ 逆向, 无主体 | 逆向；便宜，稳定性无保证。 |
 | 🟢 [CloseAI](https://www.closeai-asia.com) | official-relay | 支付宝/微信/对公 | active · 2026-05-26 · 已注册 | 提供对公发票；自称亚洲最大企业级中转。 |
+| 🟡 [玄枢API (XuanShu API)](https://www.xuanshuapi.com) | mixed | 对公 | unverified · ⚠ 自荐 | 根路径提供 Anthropic Messages 与 Gemini v1beta，/v1 下提供 OpenAI Responses 与 Chat Completions；模型可见性与价格按 Key 和分组在控制台配置。 |
+| 🟡 [TeamoRouter](https://teamorouter.com) | mixed | 支付宝/微信 | unverified · ⚠ 自荐 | 兼容 OpenAI／Anthropic／Gemini 的网关；支付宝与微信支付；运营方宣称多上游路由，并有 Claude Code／Codex 配置教程。 |
+| 🟡 [wawazz.xyz](https://wawazz.xyz) | mixed | 微信 | unverified · ⚠ 自荐, 价过低 | OpenAI 兼容 `/v1`；微信支付；运营方宣称 GPT 可低至官方价 0.07 倍。 |
+| 🟡 [Wappkit API](https://api.wappkit.com) | mixed | — | unverified · ⚠ 自荐 | new-api OpenAI 兼容网关，公开 `/api/pricing`；分组为 Codex／Claude-Code 号池（无扁平 default 组）。 |
 <!-- providers:china_relays:end -->
 
 > **收录 ≠ 推荐。** 收录是为了记录市场。打款或传数据前请先走
@@ -115,6 +119,12 @@ OpenAI、Anthropic、Google 等官方 API，而是把 `base_url` 改成中转站
 | 🟢 [AIMLAPI](https://aimlapi.com) | aggregator | 卡/加密货币 | 400+ 模型，$20 起预付；支持加密货币暗示绕支付障碍。 |
 | 🟡 [RouteScope](https://www.routescope.ai) | aggregator | 卡/加密货币 | 统一网关，将 100+ 模型转成 OpenAI／Claude／Gemini 兼容 API；按量预付额度。 |
 | 🟡 [UnoRouter](https://unorouter.ai) | aggregator | 卡 | 建于 new-api 网关之上。单一密钥跨多上游，按延迟路由并具故障转移；自动识别 OpenAI／Anthropic／Gemini 格式。按量计费并提供免费模型层；亦支持角色扮演客户端（SillyTavern、Janitor.AI、RisuAI、Chub）。 |
+| 🟡 [QuickSilver Pro](https://quicksilverpro.io) | aggregator | 卡 | OpenAI 兼容网关；单一密钥涵盖前沿与开源模型（Claude、GPT、Gemini、DeepSeek、Qwen、Kimi、GLM）。按量计费。公开 `/pricing.json`。运营方自称 MachineFi Labs。 |
+| 🟡 [NovAI](https://aiapi-pro.com) | aggregator | 卡/加密货币 | OpenAI 兼容聚合网关，整合中国前沿模型（DeepSeek、Qwen、GLM、Kimi、MiniMax、Doubao、Hunyuan），同一 `/v1` 端点另含图像与视频生成；`/v1/models` 公开模型清单，定价页列每 token 价格。 |
+| 🟡 [SandBase](https://sandbase.ai) | aggregator | 卡 | 统一 API，OpenAI 兼容端点涵盖多家模型供应商，另有 tool API 与托管 agent。运营方未亲自验证线上 API。 |
+| 🟡 [AllRouter](https://allrouter.ai) | aggregator | 支付宝/微信 | 兼容 OpenAI 与 Anthropic 的聚合网关；支持支付宝与微信支付；运营方宣称 Kimi K3 为 Moonshot 官方牌价。 |
+| 🟡 [AI Router](https://ai-router.dev) | mixed | 卡/加密货币/支付宝/微信 | OpenAI 兼容 ChatGPT API 中转（`api.ai-router.dev/v1`）；控制台密钥与用量追踪、日／周套餐；英／中／俄／波斯语页面。 |
+| 🟡 [Tokens Forge](https://tokens-forge.com) | aggregator | 卡/微信 | OpenAI 兼容多模型 API 网关；GPT／Claude／Gemini 类模型分官方额度与路由钱包余额。 |
 <!-- providers:global_gateways:end -->
 
 ## 自托管替代方案
@@ -143,6 +153,7 @@ OpenAI、Anthropic、Google 等官方 API，而是把 `base_url` 改成中转站
 |---|---|
 | 🟢 [中轉站競技場 (AI API PK)](https://www.aiapipk.com) | 约 40 家站点的 OpenAI / 逆向 / Claude / DeepSeek 报价墙。 |
 | 🔴 [awesome-ai-proxy (mn-api, unmaintained)](https://github.com/mn-api/awesome-ai-proxy) | 最早的清单（约 31 家）。**2026 年起已停更** —— 本仓库延续这一工作。 |
+| 🟡 [China AI Arbitrage](https://www.china-ai-arbitrage.xyz) | 60+ 中国 AI 平台的价格与额度比价、LLM API 中转站排名、每日更新的免费额度追踪。 |
 | 🟡 [CoderPlan](https://coderplan.ai) | 社区投稿；宣称 50+ 模型，含 OpenAI/Anthropic/Google/DeepSeek/xAI。 |
 <!-- providers:comparison_tools:end -->
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -97,6 +97,10 @@ OpenAI、Anthropic、Google 等官方 API，而是把 `base_url` 改成中轉站
 | 🟡 [MKEAI](https://mkeai.com) | mixed | 支付寶/微信 | unverified · ⚠ 無主體 | 社群論壇 + 中轉混合；主推 DeepSeek。 |
 | 🟡 [GPTGOD](https://gptgod.online) | reverse | 支付寶 | unverified · ⚠ 逆向, 無主體 | 逆向；便宜，穩定性無保證。 |
 | 🟢 [CloseAI](https://www.closeai-asia.com) | official-relay | 支付寶/微信/對公 | active · 2026-05-26 · 已註冊 | 提供對公發票；自稱亞洲最大企業級中轉。 |
+| 🟡 [玄枢API (XuanShu API)](https://www.xuanshuapi.com) | mixed | 對公 | unverified · ⚠ 自薦 | 根路徑提供 Anthropic Messages 與 Gemini v1beta，/v1 下提供 OpenAI Responses 與 Chat Completions；模型可見性與價格依 Key 與分組在控制台設定。 |
+| 🟡 [TeamoRouter](https://teamorouter.com) | mixed | 支付寶/微信 | unverified · ⚠ 自薦 | 相容 OpenAI／Anthropic／Gemini 的閘道；支付寶與微信支付；運營方宣稱多上游路由，並有 Claude Code／Codex 設定教學。 |
+| 🟡 [wawazz.xyz](https://wawazz.xyz) | mixed | 微信 | unverified · ⚠ 自薦, 價過低 | OpenAI 相容 `/v1`；微信支付；運營方宣稱 GPT 可低至官方價 0.07 倍。 |
+| 🟡 [Wappkit API](https://api.wappkit.com) | mixed | — | unverified · ⚠ 自薦 | new-api OpenAI 相容閘道，公開 `/api/pricing`；分組為 Codex／Claude-Code 號池（無扁平 default 組）。 |
 <!-- providers:china_relays:end -->
 
 > **收錄 ≠ 推薦。** 收錄是為了記錄市場。打款或傳資料前請先走
@@ -115,6 +119,12 @@ OpenAI、Anthropic、Google 等官方 API，而是把 `base_url` 改成中轉站
 | 🟢 [AIMLAPI](https://aimlapi.com) | aggregator | 卡/加密貨幣 | 400+ 模型，$20 起預付；支援加密貨幣暗示繞支付障礙。 |
 | 🟡 [RouteScope](https://www.routescope.ai) | aggregator | 卡/加密貨幣 | 統一閘道，將 100+ 模型轉成 OpenAI／Claude／Gemini 相容 API；按量預付額度。 |
 | 🟡 [UnoRouter](https://unorouter.ai) | aggregator | 卡 | 建於 new-api 閘道之上。單一金鑰跨多上游，依延遲路由並具故障轉移；自動辨識 OpenAI／Anthropic／Gemini 格式。按量計費並提供免費模型層；亦支援角色扮演用戶端（SillyTavern、Janitor.AI、RisuAI、Chub）。 |
+| 🟡 [QuickSilver Pro](https://quicksilverpro.io) | aggregator | 卡 | OpenAI 相容閘道；單一金鑰涵蓋前沿與開源模型（Claude、GPT、Gemini、DeepSeek、Qwen、Kimi、GLM）。按量計費。公開 `/pricing.json`。運營方自稱 MachineFi Labs。 |
+| 🟡 [NovAI](https://aiapi-pro.com) | aggregator | 卡/加密貨幣 | OpenAI 相容聚合閘道，整合中國前沿模型（DeepSeek、Qwen、GLM、Kimi、MiniMax、Doubao、Hunyuan），同一 `/v1` 端點另含圖像與影片生成；`/v1/models` 公開模型清單，定價頁列每 token 價格。 |
+| 🟡 [SandBase](https://sandbase.ai) | aggregator | 卡 | 統一 API，OpenAI 相容端點涵蓋多家模型供應商，另有 tool API 與託管 agent。運營方未親自驗證線上 API。 |
+| 🟡 [AllRouter](https://allrouter.ai) | aggregator | 支付寶/微信 | 相容 OpenAI 與 Anthropic 的聚合閘道；支援支付寶與微信支付；運營方宣稱 Kimi K3 為 Moonshot 官方牌價。 |
+| 🟡 [AI Router](https://ai-router.dev) | mixed | 卡/加密貨幣/支付寶/微信 | OpenAI 相容 ChatGPT API 中轉（`api.ai-router.dev/v1`）；控制台金鑰與用量追蹤、日／週套餐；英／中／俄／波斯語頁面。 |
+| 🟡 [Tokens Forge](https://tokens-forge.com) | aggregator | 卡/微信 | OpenAI 相容多模型 API 閘道；GPT／Claude／Gemini 類模型分官方額度與路由錢包餘額。 |
 <!-- providers:global_gateways:end -->
 
 ## 自架替代方案
@@ -143,6 +153,7 @@ OpenAI、Anthropic、Google 等官方 API，而是把 `base_url` 改成中轉站
 |---|---|
 | 🟢 [中轉站競技場 (AI API PK)](https://www.aiapipk.com) | 約 40 家站點的 OpenAI / 逆向 / Claude / DeepSeek 報價牆。 |
 | 🔴 [awesome-ai-proxy (mn-api, unmaintained)](https://github.com/mn-api/awesome-ai-proxy) | 最早的清單（約 31 家）。**2026 年起已停更** —— 本倉庫延續這項工作。 |
+| 🟡 [China AI Arbitrage](https://www.china-ai-arbitrage.xyz) | 60+ 中國 AI 平台的價格與額度比價、LLM API 中轉站排名、每日更新的免費額度追蹤。 |
 | 🟡 [CoderPlan](https://coderplan.ai) | 社群投稿；宣稱 50+ 模型，含 OpenAI/Anthropic/Google/DeepSeek/xAI。 |
 <!-- providers:comparison_tools:end -->
 

--- a/data/providers.yaml
+++ b/data/providers.yaml
@@ -173,6 +173,82 @@ china_relays:
       zh-TW: "提供對公發票；自稱亞洲最大企業級中轉。"
       zh-CN: "提供对公发票；自称亚洲最大企业级中转。"
 
+  # Landed from issue #49 (JV-X), Path C operator filing.
+  - name: 玄枢API (XuanShu API)
+    url: https://www.xuanshuapi.com
+    type: mixed
+    status: unverified
+    payment: [enterprise-invoice]
+    models: [openai, anthropic, gemini]
+    last_verified: null
+    verified_by: community
+    entity_registered: unknown
+    supports_stream: true
+    supports_tools: unknown
+    risk_flags: [operator_submitted]
+    notes:
+      en: "Serves Anthropic Messages and Gemini v1beta at the root host and OpenAI Responses and Chat Completions under /v1; model visibility and pricing are per-key and per-group, set in the console."
+      zh-TW: "根路徑提供 Anthropic Messages 與 Gemini v1beta，/v1 下提供 OpenAI Responses 與 Chat Completions；模型可見性與價格依 Key 與分組在控制台設定。"
+      zh-CN: "根路径提供 Anthropic Messages 与 Gemini v1beta，/v1 下提供 OpenAI Responses 与 Chat Completions；模型可见性与价格按 Key 和分组在控制台配置。"
+
+  # Landed from issue #45 (kwu18-png). Marketing copy stripped; type mixed.
+  - name: TeamoRouter
+    url: https://teamorouter.com
+    type: mixed
+    status: unverified
+    payment: [alipay, wechat]
+    models: [openai, anthropic, gemini, deepseek]
+    last_verified: null
+    verified_by: community
+    entity_registered: unknown
+    supports_stream: unknown
+    supports_tools: unknown
+    risk_flags: [operator_submitted]
+    notes:
+      en: "OpenAI / Anthropic / Gemini-compatible gateway; Alipay and WeChat; operator-claimed multi-upstream routing and Claude Code / Codex setup guides."
+      zh-TW: "相容 OpenAI／Anthropic／Gemini 的閘道；支付寶與微信支付；運營方宣稱多上游路由，並有 Claude Code／Codex 設定教學。"
+      zh-CN: "兼容 OpenAI／Anthropic／Gemini 的网关；支付宝与微信支付；运营方宣称多上游路由，并有 Claude Code／Codex 配置教程。"
+
+  # Landed from issue #28 (LRZ1918). 0.07x claim is a cheap-trap signal, not a selling point.
+  - name: wawazz.xyz
+    url: https://wawazz.xyz
+    type: mixed
+    status: unverified
+    payment: [wechat]
+    models: [openai, anthropic]
+    last_verified: null
+    verified_by: community
+    entity_registered: unknown
+    supports_stream: unknown
+    supports_tools: unknown
+    risk_flags: [operator_submitted, prices_too_cheap]
+    notes:
+      en: "OpenAI-compatible API at /v1; WeChat pay; operator-claimed GPT pricing as low as 0.07x official."
+      zh-TW: "OpenAI 相容 `/v1`；微信支付；運營方宣稱 GPT 可低至官方價 0.07 倍。"
+      zh-CN: "OpenAI 兼容 `/v1`；微信支付；运营方宣称 GPT 可低至官方价 0.07 倍。"
+
+  # Landed from issue #22 (alicekellings). Public new-api /api/pricing (GPT groups).
+  - name: Wappkit API
+    url: https://api.wappkit.com
+    type: mixed
+    status: unverified
+    models: [openai, anthropic]
+    last_verified: null
+    verified_by: community
+    entity_registered: unknown
+    supports_stream: unknown
+    supports_tools: unknown
+    risk_flags: [operator_submitted]
+    pricing:
+      pricing_url: https://api.wappkit.com
+      api_url: https://api.wappkit.com/api/pricing
+      fetcher: wappkit
+      pricing_currency: USD
+    notes:
+      en: "new-api OpenAI-compatible gateway with public /api/pricing; listed groups are Codex/Claude-Code pools (no flat default group)."
+      zh-TW: "new-api OpenAI 相容閘道，公開 `/api/pricing`；分組為 Codex／Claude-Code 號池（無扁平 default 組）。"
+      zh-CN: "new-api OpenAI 兼容网关，公开 `/api/pricing`；分组为 Codex／Claude-Code 号池（无扁平 default 组）。"
+
 # ---------------------------------------------------------------------------
 # Comparison / monitoring tools (中轉站對比工具)
 # ---------------------------------------------------------------------------
@@ -198,6 +274,19 @@ comparison_tools:
       en: "Original list (~31 stations); no longer maintained as of 2026."
       zh-TW: "最早的清單（約 31 家）。**2026 年起已停更** —— 本倉庫延續這項工作。"
       zh-CN: "最早的清单（约 31 家）。**2026 年起已停更** —— 本仓库延续这一工作。"
+
+  # Landed from PR #53 (the-beating-light-of-the-nail). Operator self-submission.
+  - name: China AI Arbitrage
+    url: https://www.china-ai-arbitrage.xyz
+    type: comparison
+    status: unverified
+    last_verified: null
+    verified_by: community
+    risk_flags: [operator_submitted]
+    notes:
+      en: "Price and quota comparison of 60+ Chinese AI platforms, ranked LLM API relays, and daily-updated free-tier tracking."
+      zh-TW: "60+ 中國 AI 平台的價格與額度比價、LLM API 中轉站排名、每日更新的免費額度追蹤。"
+      zh-CN: "60+ 中国 AI 平台的价格与额度比价、LLM API 中转站排名、每日更新的免费额度追踪。"
 
 # ---------------------------------------------------------------------------
 # Global gateways / aggregators (海外對比方案)
@@ -378,6 +467,122 @@ global_gateways:
       en: "Built on the new-api gateway. One key across multiple upstreams with latency-based routing and failover; OpenAI/Anthropic/Gemini formats auto-detected. Pay-as-you-go credits plus a free model tier. Also targets roleplay clients (SillyTavern, Janitor.AI, RisuAI, Chub). Public pricing JSON at /api/pricing."
       zh-TW: "建於 new-api 閘道之上。單一金鑰跨多上游，依延遲路由並具故障轉移；自動辨識 OpenAI／Anthropic／Gemini 格式。按量計費並提供免費模型層；亦支援角色扮演用戶端（SillyTavern、Janitor.AI、RisuAI、Chub）。"
       zh-CN: "建于 new-api 网关之上。单一密钥跨多上游，按延迟路由并具故障转移；自动识别 OpenAI／Anthropic／Gemini 格式。按量计费并提供免费模型层；亦支持角色扮演客户端（SillyTavern、Janitor.AI、RisuAI、Chub）。"
+
+  # Landed from PR #52 (raullenchai). Public /pricing.json → fetcher.
+  - name: QuickSilver Pro
+    url: https://quicksilverpro.io
+    type: aggregator
+    status: unverified
+    payment: [card]
+    models: [openai, anthropic, gemini, deepseek, qwen, moonshotai, zhipuai, minimax, meta, xai]
+    model_count: 39
+    discount_vs_official: "~20% below OpenRouter on comparable models (claimed)"
+    last_verified: null
+    verified_by: community
+    entity_registered: unknown
+    supports_stream: true
+    supports_tools: true
+    risk_flags: [operator_submitted]
+    pricing:
+      pricing_url: https://quicksilverpro.io
+      api_url: https://quicksilverpro.io/pricing.json
+      fetcher: quicksilverpro
+      pricing_currency: USD
+    notes:
+      en: "OpenAI-compatible gateway; one key for frontier and open models (Claude, GPT, Gemini, DeepSeek, Qwen, Kimi, GLM). Pay-as-you-go. Public pricing JSON at /pricing.json. Operated by MachineFi Labs (claimed)."
+      zh-TW: "OpenAI 相容閘道；單一金鑰涵蓋前沿與開源模型（Claude、GPT、Gemini、DeepSeek、Qwen、Kimi、GLM）。按量計費。公開 `/pricing.json`。運營方自稱 MachineFi Labs。"
+      zh-CN: "OpenAI 兼容网关；单一密钥涵盖前沿与开源模型（Claude、GPT、Gemini、DeepSeek、Qwen、Kimi、GLM）。按量计费。公开 `/pricing.json`。运营方自称 MachineFi Labs。"
+
+  # Landed from issues #47 / #44 (vvvvking). #47 aggregator is the honest type.
+  - name: NovAI
+    url: https://aiapi-pro.com
+    type: aggregator
+    status: unverified
+    payment: [card, crypto]
+    models: [deepseek, qwen, moonshot, zhipu, doubao, minimax, hunyuan, seedance]
+    model_count: 38
+    last_verified: null
+    verified_by: community
+    entity_registered: unknown
+    supports_stream: true
+    supports_tools: unknown
+    risk_flags: [operator_submitted]
+    notes:
+      en: "OpenAI-compatible aggregator for Chinese frontier models (DeepSeek, Qwen, GLM, Kimi, MiniMax, Doubao, Hunyuan) plus image and video generation on one /v1 endpoint; public model list at /v1/models, per-token prices on the pricing page."
+      zh-TW: "OpenAI 相容聚合閘道，整合中國前沿模型（DeepSeek、Qwen、GLM、Kimi、MiniMax、Doubao、Hunyuan），同一 `/v1` 端點另含圖像與影片生成；`/v1/models` 公開模型清單，定價頁列每 token 價格。"
+      zh-CN: "OpenAI 兼容聚合网关，整合中国前沿模型（DeepSeek、Qwen、GLM、Kimi、MiniMax、Doubao、Hunyuan），同一 `/v1` 端点另含图像与视频生成；`/v1/models` 公开模型清单，定价页列每 token 价格。"
+
+  # Landed from issue #54 (denial123789). docs.sandbase.ai did not resolve at triage.
+  - name: SandBase
+    url: https://sandbase.ai
+    type: aggregator
+    status: unverified
+    payment: [card]
+    models: [openai, anthropic, gemini, deepseek, qwen, meta, mistral]
+    last_verified: null
+    verified_by: community
+    entity_registered: unknown
+    supports_stream: unknown
+    supports_tools: unknown
+    risk_flags: [operator_submitted]
+    notes:
+      en: "Unified API with OpenAI-compatible endpoints for multiple model providers, plus tool APIs and managed agents. Operator did not personally verify the live API."
+      zh-TW: "統一 API，OpenAI 相容端點涵蓋多家模型供應商，另有 tool API 與託管 agent。運營方未親自驗證線上 API。"
+      zh-CN: "统一 API，OpenAI 兼容端点涵盖多家模型供应商，另有 tool API 与托管 agent。运营方未亲自验证线上 API。"
+
+  # Landed from issue #50 (toptok369-jpg). Marketing claims stripped.
+  - name: AllRouter
+    url: https://allrouter.ai
+    type: aggregator
+    status: unverified
+    payment: [alipay, wechat]
+    models: [openai, anthropic, moonshot, zhipu, gemma, deepseek]
+    last_verified: null
+    verified_by: community
+    entity_registered: unknown
+    supports_stream: unknown
+    supports_tools: unknown
+    risk_flags: [operator_submitted]
+    notes:
+      en: "OpenAI and Anthropic-compatible aggregator; Alipay and WeChat accepted; operator-claimed Kimi K3 at official Moonshot list price."
+      zh-TW: "相容 OpenAI 與 Anthropic 的聚合閘道；支援支付寶與微信支付；運營方宣稱 Kimi K3 為 Moonshot 官方牌價。"
+      zh-CN: "兼容 OpenAI 与 Anthropic 的聚合网关；支持支付宝与微信支付；运营方宣称 Kimi K3 为 Moonshot 官方牌价。"
+
+  # Landed from issue #32 (airouter-dev).
+  - name: AI Router
+    url: https://ai-router.dev
+    type: mixed
+    status: unverified
+    payment: [card, crypto, alipay, wechat]
+    models: [openai]
+    last_verified: null
+    verified_by: community
+    entity_registered: unknown
+    supports_stream: unknown
+    supports_tools: unknown
+    risk_flags: [operator_submitted]
+    notes:
+      en: "OpenAI-compatible ChatGPT API relay at api.ai-router.dev/v1 with dashboard API keys, usage tracking, daily/weekly packages, and localized English/Chinese/Russian/Persian pages."
+      zh-TW: "OpenAI 相容 ChatGPT API 中轉（`api.ai-router.dev/v1`）；控制台金鑰與用量追蹤、日／週套餐；英／中／俄／波斯語頁面。"
+      zh-CN: "OpenAI 兼容 ChatGPT API 中转（`api.ai-router.dev/v1`）；控制台密钥与用量追踪、日／周套餐；英／中／俄／波斯语页面。"
+
+  # Landed from issue #26 (ryisegg).
+  - name: Tokens Forge
+    url: https://tokens-forge.com
+    type: aggregator
+    status: unverified
+    payment: [card, wechat]
+    models: [openai, anthropic, gemini]
+    last_verified: null
+    verified_by: community
+    entity_registered: unknown
+    supports_stream: unknown
+    supports_tools: unknown
+    risk_flags: [operator_submitted]
+    notes:
+      en: "OpenAI-compatible multi-model API gateway with separate official credit and routed wallet balances for GPT, Claude, and Gemini-style models."
+      zh-TW: "OpenAI 相容多模型 API 閘道；GPT／Claude／Gemini 類模型分官方額度與路由錢包餘額。"
+      zh-CN: "OpenAI 兼容多模型 API 网关；GPT／Claude／Gemini 类模型分官方额度与路由钱包余额。"
 
 # ---------------------------------------------------------------------------
 # Self-hosted alternatives (自架閘道，供參考對比 — 非「中轉站」)

--- a/fetchers/__init__.py
+++ b/fetchers/__init__.py
@@ -19,6 +19,8 @@ REGISTRY: dict[str, str] = {
     "uiuiapi": "fetchers.uiuiapi",
     "bltcy": "fetchers.bltcy",
     "unorouter": "fetchers.unorouter",
+    "quicksilverpro": "fetchers.quicksilverpro",
+    "wappkit": "fetchers.wappkit",
 }
 
 

--- a/fetchers/quicksilverpro.py
+++ b/fetchers/quicksilverpro.py
@@ -1,0 +1,61 @@
+"""QuickSilver Pro — public /pricing.json catalog (already $/1M or $/image).
+
+Operator-submitted aggregator. Catalog is generated from their model list;
+do not treat `discount_vs_official` as independently verified.
+"""
+
+from __future__ import annotations
+
+from ._common import FetchResult, PriceRecord, http_client
+
+PROVIDER_ID = "quicksilverpro"
+PROVIDER_NAME = "QuickSilver Pro"
+SOURCE_URL = "https://quicksilverpro.io/pricing.json"
+DISPLAY_URL = "https://quicksilverpro.io"
+
+
+def fetch() -> FetchResult:
+    with http_client() as c:
+        r = c.get(SOURCE_URL)
+        r.raise_for_status()
+        payload = r.json()
+
+    models = payload.get("models") or []
+    records: list[PriceRecord] = []
+    for m in models:
+        model_id = m.get("id")
+        if not model_id:
+            continue
+        for src_key, unit in (
+            ("input_per_1m", "per_1m_input_tokens"),
+            ("output_per_1m", "per_1m_output_tokens"),
+            ("cached_input_per_1m", "per_1m_input_cache_read_tokens"),
+            ("output_per_image", "per_image"),
+        ):
+            raw = m.get(src_key)
+            if raw is None:
+                continue
+            try:
+                price = float(raw)
+            except (TypeError, ValueError):
+                continue
+            if price <= 0:
+                continue
+            records.append(
+                PriceRecord(
+                    provider_id=PROVIDER_ID,
+                    provider_name=PROVIDER_NAME,
+                    raw_model_name=model_id,
+                    channel_type="aggregator",
+                    unit=unit,  # type: ignore[arg-type]
+                    price_usd=price,
+                    source_url=DISPLAY_URL,
+                    method="json-api",
+                )
+            )
+
+    return FetchResult(
+        provider_id=PROVIDER_ID,
+        records=records,
+        raw_model_count=len(models),
+    )

--- a/fetchers/wappkit.py
+++ b/fetchers/wappkit.py
@@ -1,0 +1,29 @@
+"""Wappkit API — new-api fork. Thin wrapper over fetchers._new_api.
+
+Public /api/pricing has no flat `default` group. Every listed model is in
+`Codex-Pro(救急)` (group_ratio 0.3); other Codex/Claude-Code pools exist in
+group_ratio but are not attached to the published model rows.
+"""
+
+from __future__ import annotations
+
+from ._common import FetchResult
+from ._new_api import fetch_new_api
+
+PROVIDER_ID = "wappkit"
+PROVIDER_NAME = "Wappkit API"
+SOURCE_URL = "https://api.wappkit.com/api/pricing"
+DISPLAY_URL = "https://api.wappkit.com"
+# Only group that currently appears on enable_groups for published models.
+_GROUP = "Codex-Pro(救急)"
+
+
+def fetch() -> FetchResult:
+    return fetch_new_api(
+        provider_id=PROVIDER_ID,
+        provider_name=PROVIDER_NAME,
+        pricing_api_url=SOURCE_URL,
+        public_pricing_url=DISPLAY_URL,
+        channel_type="mixed",
+        group=_GROUP,
+    )


### PR DESCRIPTION
## What this changes

Maintainer triage of every open issue and the two station PRs. Adds 11 stations as `status: unverified` + `risk_flags: [operator_submitted]`, plus price fetchers for the two that expose public JSON.

Does **not** merge the weekly price-refresh PR (#43) — that is a separate 80k-line snapshot (2026-08-16) and still has no CI because the bot opened it with `GITHUB_TOKEN`.

## Landed

| Source | Station | Section | Notes |
|---|---|---|---|
| PR #52 | QuickSilver Pro | `global_gateways` | fetcher `quicksilverpro` (`/pricing.json`) |
| PR #53 | China AI Arbitrage | `comparison_tools` | added missing `operator_submitted` |
| #22 | Wappkit API | `china_relays` | fetcher `wappkit` (new-api, group `Codex-Pro(救急)`) |
| #26 | Tokens Forge | `global_gateways` | |
| #28 | wawazz.xyz | `china_relays` | also `prices_too_cheap` (0.07x claim) |
| #32 | AI Router | `global_gateways` | |
| #45 | TeamoRouter | `china_relays` | marketing copy stripped |
| #47 / #44 | NovAI | `global_gateways` | #47 aggregator is the honest type; #44 official-relay dropped |
| #49 | 玄枢API (XuanShu API) | `china_relays` | |
| #50 | AllRouter | `global_gateways` | marketing claims stripped |
| #54 | SandBase | `global_gateways` | `docs.sandbase.ai` did not resolve |

## Rejected

- **#51** DeepSeek V4 Fast Node — marketing title, Gumroad sales link, no homepage, `api.ycsgyuuu.study/v1` returns 404.

## Checklist

- [x] Edited `data/providers.yaml` only for catalog (READMEs regenerated)
- [x] `status: unverified` on every new entry
- [x] Self-submissions: `risk_flags: [operator_submitted]`
- [x] Plain `https://` URLs
- [x] No marketing superlatives in `notes`
- [x] Fetchers registered in `fetchers/__init__.REGISTRY`
- [x] `python -m scripts.validate` exit 0
- [x] Fetchers smoke-tested live (`quicksilverpro` 39 models / 100 records, `wappkit` 6 models / 12 records)

## Source / verification

HTTP GET of each homepage (and public JSON where claimed) on 2026-08-18. No maintainer canary — nothing promoted to `active`.