### PR TITLE
Add TrustGate (NeuralTrust) to self-hosted alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ templates.
 |---|---|---|
 | 🟢 [One-API](https://github.com/songquanpeng/one-api) | gateway-oss | Popular Go-based self-hosted multi-vendor gateway; the de-facto OSS template behind many relay stations. |
 | 🟢 [new-api](https://github.com/Calcium-Ion/new-api) | gateway-oss | Fork of One-API with extra channel types; same self-hosted model — you supply keys. |
+| 🟢 [TrustGate](https://github.com/NeuralTrust/TrustGate) | gateway-oss | Self-hosted Go Agent Gateway (Apache-2.0): OpenAI-compatible LLM proxy + MCP aggregation, per-consumer auth/audit. |
 | 🟡 [A3M Router](https://github.com/Das-rebel/a3m-router) | gateway-oss | MIT TypeScript OpenAI-compatible multi-provider router (parallel ensemble); self-hosted — you supply keys. npm: adaptive-memory-multi-model-router. |
 <!-- providers:self_hosted_alternatives:end -->
 


### PR DESCRIPTION
## Summary
Adds [TrustGate](https://github.com/NeuralTrust/TrustGate) under **Self-hosted alternatives** — a Go, Apache-2.0 self-hosted Agent Gateway (OpenAI-compatible LLM proxy + MCP aggregation, per-consumer auth/audit).

Fits this list’s self-hosted / you-supply-keys framing next to One-API / new-api / LiteLLM.

## Disclosure
Submitted while building TrustGate at NeuralTrust (CTO). Happy to adjust wording/placement to match house style.