### PR TITLE
add: Bifrost (gateway-oss)

### DIFF
--- a/data/providers.yaml
+++ b/data/providers.yaml
@@ -643,5 +643,6 @@ self_hosted_alternatives:
     entity_registered: unknown
     supports_stream: true
     supports_tools: true
+    risk_flags: [operator_submitted]
     notes:
       en: "Go-based self-hosted AI gateway with an OpenAI-compatible API, multi-provider routing, fallbacks, load balancing, and observability; users supply their own provider keys."

--- a/data/providers.yaml
+++ b/data/providers.yaml
@@ -632,3 +632,16 @@ self_hosted_alternatives:
     risk_flags: [operator_submitted]
     notes:
       en: "MIT TypeScript OpenAI-compatible multi-provider router (parallel ensemble); self-hosted — you supply keys. npm: adaptive-memory-multi-model-router."
+
+  - name: Bifrost
+    url: https://github.com/maximhq/bifrost
+    type: gateway-oss
+    status: unverified
+    models: [openai, anthropic, google, azure, bedrock, groq, mistral]
+    last_verified: null
+    verified_by: community
+    entity_registered: unknown
+    supports_stream: true
+    supports_tools: true
+    notes:
+      en: "Go-based self-hosted AI gateway with an OpenAI-compatible API, multi-provider routing, fallbacks, load balancing, and observability; users supply their own provider keys."


### PR DESCRIPTION
## What this changes

Adds Bifrost to the self-hosted alternatives catalog in `data/providers.yaml`.

## Checklist

- [x] Edited `data/providers.yaml` only (not the README tables; they auto-regenerate)
- [x] Followed [`data/schema.md`](../data/schema.md)
- [x] Used `status: unverified`
- [x] Self-submission is marked with `risk_flags: [operator_submitted]`
- [x] Plain `https://` URL only, with no tracking or affiliate parameters
- [x] Notes contain one factual sentence without marketing claims
- [x] Source and verification details are included below
- [ ] Price fetcher: not applicable

## Source / verification

Checked on 2026-09-01 against the official [Bifrost repository](https://github.com/maximhq/bifrost) and its README. The entry describes the documented self-hosted gateway, OpenAI-compatible API, multi-provider routing, fallbacks, load balancing, observability, and user-supplied provider keys.

The project is listed as `gateway-oss`, with `status: unverified` because this catalog entry has not been independently verified by a maintainer.

## Are you the operator of this station?

yes, this is an affiliated submission for the Bifrost project. It is disclosed with `risk_flags: [operator_submitted]` and remains `status: unverified`.